### PR TITLE
Add dependabot support for git

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.2-canary.5.eecc514.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chez14/mal-api-lite@1.0.2-canary.5.eecc514.0
  # or 
  yarn add @chez14/mal-api-lite@1.0.2-canary.5.eecc514.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
